### PR TITLE
Faulty removal of @critical rule when used with a subset of styles

### DIFF
--- a/lib/getChildRules.js
+++ b/lib/getChildRules.js
@@ -30,22 +30,22 @@ function getChildRules(css, parent) {
     if (childRule) {
       result.push(rule);
     }
-  });
+  }
 
   // Walk all at-rules to match nested child selectors
-  css.walkAtRules(function (atRule) {
+  );css.walkAtRules(function (atRule) {
     atRule.walkRules(selectorRegExp, function (rule) {
-      var childRule = (0, _matchChild.matchChild)(parent, rule);
+      var childRule = (0, _matchChild.matchChild)(parent, rule
       // Create new at-rule to append only necessary selector to critical
-      var criticalAtRule = _postcss2.default.atRule({
+      );var criticalAtRule = _postcss2.default.atRule({
         name: atRule.name,
         params: atRule.params
-      });
+      }
       /**
        * Should append even if parent selector, but make sure the two rules
        * aren't identical.
        */
-      if ((rule.selector === parent.selector || childRule) && _postcss2.default.parse(rule).toString() !== _postcss2.default.parse(parent).toString()) {
+      );if ((rule.selector === parent.selector || childRule) && _postcss2.default.parse(rule).toString() !== _postcss2.default.parse(parent).toString()) {
         var clone = rule.clone();
         criticalAtRule.append(clone);
         result.push(criticalAtRule);

--- a/lib/index.js
+++ b/lib/index.js
@@ -26,6 +26,8 @@ function _interopRequireDefault(obj) { return obj && obj.__esModule ? obj : { de
 
 function _defineProperty(obj, key, value) { if (key in obj) { Object.defineProperty(obj, key, { value: value, enumerable: true, configurable: true, writable: true }); } else { obj[key] = value; } return obj; }
 
+var append = false;
+
 /**
  * Clean the original root node passed to the plugin, removing custom atrules,
  * properties. Will additionally delete nodes as appropriate if
@@ -41,9 +43,9 @@ function clean(root, preserve) {
     } else {
       atRule.remove();
     }
-  });
+  }
   // @TODO `scope` Makes this kind of gnarly. This could be cleaned up a bit.
-  root.walkDecls(/critical-(selector|filename)/, function (decl) {
+  );root.walkDecls(/critical-(selector|filename)/, function (decl) {
     if (preserve === false) {
       if (decl.value === 'scope') {
         root.walk(function (node) {
@@ -121,7 +123,8 @@ function hasNoOtherChildNodes() {
  * @param {string} css CSS to write to file.
  */
 function writeCriticalFile(filePath, css) {
-  _fs2.default.writeFile(filePath, css, function (err) {
+  _fs2.default.writeFile(filePath, css, { flag: append ? 'a' : 'w' }, function (err) {
+    append = true;
     if (err) {
       console.error(err);
       process.exit(1);
@@ -148,6 +151,7 @@ function buildCritical() {
     minify: true,
     dryRun: false
   }, filteredOptions);
+  append = false;
   return function (css) {
     var dryRun = args.dryRun,
         preserve = args.preserve,

--- a/lib/index.js
+++ b/lib/index.js
@@ -38,10 +38,18 @@ var append = false;
  */
 function clean(root, preserve) {
   root.walkAtRules('critical', function (atRule) {
-    if (preserve === false && !atRule.nodes) {
-      root.removeAll();
+    if (preserve === false) {
+      if (atRule.nodes && atRule.nodes.length) {
+        atRule.remove();
+      } else {
+        root.removeAll();
+      }
     } else {
-      atRule.remove();
+      if (atRule.nodes && atRule.nodes.length) {
+        atRule.replaceWith(atRule.nodes);
+      } else {
+        atRule.remove();
+      }
     }
   }
   // @TODO `scope` Makes this kind of gnarly. This could be cleaned up a bit.

--- a/src/index.js
+++ b/src/index.js
@@ -7,6 +7,8 @@ import fs from 'fs'
 import path from 'path'
 import { getCriticalRules } from './getCriticalRules'
 
+let append = false
+
 /**
  * Clean the original root node passed to the plugin, removing custom atrules,
  * properties. Will additionally delete nodes as appropriate if
@@ -107,7 +109,8 @@ function hasNoOtherChildNodes (
  * @param {string} css CSS to write to file.
  */
 function writeCriticalFile (filePath: string, css: string) {
-  fs.writeFile(filePath, css, { flag: 'a' }, (err: Object) => {
+  fs.writeFile(filePath, css, { flag: append ? 'a' : 'w' }, (err: Object) => {
+    append = true
     if (err) {
       console.error(err)
       process.exit(1)
@@ -137,6 +140,7 @@ function buildCritical (options: Object = {}): Function {
     dryRun: false,
     ...filteredOptions
   }
+  append = false
   return (css: Object): Object => {
     const { dryRun, preserve, minify, outputPath, outputDest } = args
     const criticalOutput = getCriticalRules(css, outputDest)

--- a/src/index.js
+++ b/src/index.js
@@ -107,7 +107,7 @@ function hasNoOtherChildNodes (
  * @param {string} css CSS to write to file.
  */
 function writeCriticalFile (filePath: string, css: string) {
-  fs.writeFile(filePath, css, (err: Object) => {
+  fs.writeFile(filePath, css, { flag: 'a' }, (err: Object) => {
     if (err) {
       console.error(err)
       process.exit(1)

--- a/src/index.js
+++ b/src/index.js
@@ -19,10 +19,18 @@ let append = false
  */
 function clean (root: Object, preserve: boolean) {
   root.walkAtRules('critical', (atRule: Object) => {
-    if (preserve === false && !atRule.nodes) {
-      root.removeAll()
+    if (preserve === false) {
+      if (atRule.nodes && atRule.nodes.length) {
+        atRule.remove()
+      } else {
+        root.removeAll()
+      }
     } else {
-      atRule.remove()
+      if (atRule.nodes && atRule.nodes.length) {
+        atRule.replaceWith(atRule.nodes)
+      } else {
+        atRule.remove()
+      }
     }
   })
   // @TODO `scope` Makes this kind of gnarly. This could be cleaned up a bit.

--- a/test/fixtures/atRule-wrapping.non-critical.actual.css
+++ b/test/fixtures/atRule-wrapping.non-critical.actual.css
@@ -2,3 +2,8 @@
   color: gold;
   height: 100px;
 }
+
+.bar {
+    color: tomato;
+    height: 200px;
+  }

--- a/test/fixtures/atRule-wrapping.non-critical.expected.css
+++ b/test/fixtures/atRule-wrapping.non-critical.expected.css
@@ -2,3 +2,8 @@
   color: gold;
   height: 100px;
 }
+
+.bar {
+    color: tomato;
+    height: 200px;
+  }


### PR DESCRIPTION
So far, `@critical` rules with enclosed styles got removed from the non-critical CSS even if `preserve` was set to `true` (which is wrong as far as I understood). This pull request fixes this along with the faulty test fixture file `atRule-wrapping.non-critical.expected.css`.